### PR TITLE
Fix GCP bug

### DIFF
--- a/step3.sh
+++ b/step3.sh
@@ -59,7 +59,9 @@ sudo pip3 install h5py
 sudo pip install http://download.pytorch.org/whl/cu80/torch-0.2.0.post2-cp35-cp35m-manylinux1_x86_64.whl
 sudo pip install torchvision
 git clone https://github.com/abhmul/PyJet
+cd PyJet
 sudo pip install -e .
+cd ..
 
 # Install some other useful packages
 sudo pip3 install pillow

--- a/step3.sh
+++ b/step3.sh
@@ -9,7 +9,16 @@ mv cuda_8.0.61_375.26_linux-run cuda_8.0.61_375.26_linux.run
 chmod +x cuda_8.0.61_375.26_linux.run
 ./cuda_8.0.61_375.26_linux.run -extract=`pwd`/nvidia_installers
 cd nvidia_installers
-sudo ./NVIDIA-Linux-x86_64-375.26.run
+# sudo ./NVIDIA-Linux-x86_64-375.26.run
+sh NVIDIA-Linux-x86_64-375.26.run --extract-only
+cd NVIDIA-Linux-x86_64-375.26
+# Get the patch for the GCP fix and apply it
+wget https://gist.githubusercontent.com/tpruzina/939ca3170d1aa48a601228b7773e2bb1/raw/8ed7ac1cd1615d8e858d9b152aa1cc2da91b6cb1/gistfile1.txt
+mv gistfile1.txt gistfile1.patch
+patch -p1 < gistfile1.patch
+# Install the drivers
+sudo ./nvidia-installer
+# Install CUDA 8
 sudo modprobe nvidia
 sudo ./cuda-linux64-rel-8.0.61-21551265.run
 cd ..

--- a/step3.sh
+++ b/step3.sh
@@ -19,6 +19,7 @@ patch -p1 < gistfile1.patch
 # Install the drivers
 sudo ./nvidia-installer
 # Install CUDA 8
+cd ..
 sudo modprobe nvidia
 sudo ./cuda-linux64-rel-8.0.61-21551265.run
 cd ..


### PR DESCRIPTION
Added a patch to the nvidia drivers to fix a bug where the installation fails on Google Cloud Platform. This should resolve #3 

**Verification this works on GCP**
![Verification this works on GCP](https://user-images.githubusercontent.com/14433384/29788797-7ede0d7c-8bf9-11e7-8faf-08068e0f87df.png)

**NOTE:** This breaks the installation on AWS. **Do not** merge this pull request. A note has been added to the README on master that tells users to use this branch for Google Cloud setup.